### PR TITLE
Add Ruby 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ sudo: false
 language: ruby
 rvm:
   - 2.4.0
+  - 3.0.0
 before_install: gem install bundler -v 1.14.3

--- a/lib/action_sprout/method_object.rb
+++ b/lib/action_sprout/method_object.rb
@@ -33,6 +33,10 @@ module ActionSprout
       kwattr(*args)
     end
 
+    if Module.private_method_defined?(:ruby2_keywords)
+      ruby2_keywords(:method_object)
+    end
+
     module ClassMethods
       def call(**args, &block)
         new(**args).call(&block)

--- a/lib/action_sprout/method_object/version.rb
+++ b/lib/action_sprout/method_object/version.rb
@@ -1,5 +1,5 @@
 module ActionSprout
   module MethodObject
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
This is the recommended approach for supporting keyword arguments in both Ruby 2 and Ruby 3. When Ruby 2 support is dropped we can remove the call to `ruby2_keywords` and use this instead:

```ruby
def method_object(*args, **kwargs)
  ...
end
```